### PR TITLE
fix: partial matches also match for array in operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/GeorgeD19/json-logic-go
+module github.com/doriandekoning/json-logic-go
 
 go 1.17
 

--- a/jsonlogic.go
+++ b/jsonlogic.go
@@ -316,7 +316,7 @@ func In(a []interface{}) bool {
 		items := a[1].([]interface{})
 		result := false
 		for i := 0; i < len(items); i++ {
-			if strings.Contains(cast.ToString(items[i]), cast.ToString(a[0])) && a[0] != nil {
+			if a[0] != nil && SoftEqual(cast.ToString(items[i]), cast.ToString(a[0])) {
 				result = true
 			}
 		}

--- a/jsonlogic_test.go
+++ b/jsonlogic_test.go
@@ -298,7 +298,7 @@ func TestIn(t *testing.T) {
 	result, _ := Run(rule)
 
 	if cast.ToBool(result) != true {
-		t.Fatalf("rule should return true, instead returned %s", result)
+		t.Fatalf("rule should return true, instead returned %t", result)
 	}
 }
 
@@ -308,7 +308,16 @@ func TestInArray(t *testing.T) {
 	result, _ := Run(rule)
 
 	if cast.ToBool(result) != true {
-		t.Fatalf("rule should return true, instead returned %s", result)
+		t.Fatalf("rule should return true, instead returned %t", result)
+	}
+}
+
+func TestInArrayPartialMatch(t *testing.T) {
+	rule := `{"in":[ "Ringo", ["RingoPaul", "George"] ]}`
+
+	result, _ := Run(rule)
+	if cast.ToBool(result) != false {
+		t.Fatalf("rule should return false, instead returned %t", result)
 	}
 }
 


### PR DESCRIPTION
Currently experssions like `{"in": ["ab", ["abc"]]}` also return true, this is not according to jsonlogic spec.